### PR TITLE
Add Readme Functionality

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.1'
+ruby '2.6.3'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.3', '>= 6.0.3.7'
@@ -34,12 +34,11 @@ group :development, :test do
 end
 
 group :development do
-  # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
-  gem 'web-console', '>= 3.3.0'
-  gem 'listen', '~> 3.2'
-  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'pry-nav'
+  gem 'pry-rails'
+  gem 'pry-rescue'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,6 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    bindex (0.8.1)
     bootsnap (1.7.5)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -72,6 +71,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    coderay (1.1.3)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
     erubi (1.10.0)
@@ -85,6 +85,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
+    interception (0.5)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
     listen (3.5.1)
@@ -96,7 +97,7 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
-    method_source (1.0.0)
+    method_source (0.9.2)
     mini_mime (1.1.0)
     mini_portile2 (2.5.3)
     minitest (5.14.4)
@@ -105,6 +106,16 @@ GEM
     nokogiri (1.11.7)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-nav (0.3.0)
+      pry (>= 0.9.10, < 0.13.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
+    pry-rescue (1.5.2)
+      interception (>= 0.5)
+      pry (>= 0.12.0)
     public_suffix (4.0.6)
     puma (4.3.8)
       nio4r (~> 2.0)
@@ -180,11 +191,6 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
-    web-console (4.1.0)
-      actionview (>= 6.0.0)
-      activemodel (>= 6.0.0)
-      bindex (>= 0.4.0)
-      railties (>= 6.0.0)
     webdrivers (4.6.0)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
@@ -210,7 +216,9 @@ DEPENDENCIES
   capybara (>= 2.15)
   factory_bot_rails
   jbuilder (~> 2.7)
-  listen (~> 3.2)
+  pry-nav
+  pry-rails
+  pry-rescue
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.7)
   sass-rails (>= 6)
@@ -220,12 +228,11 @@ DEPENDENCIES
   sqlite3 (~> 1.4)
   turbolinks (~> 5)
   tzinfo-data
-  web-console (>= 3.3.0)
   webdrivers
   webpacker (~> 5.1)
 
 RUBY VERSION
-   ruby 2.7.1p83
+   ruby 2.6.3p62
 
 BUNDLED WITH
-   2.1.4
+   2.2.17

--- a/README.md
+++ b/README.md
@@ -14,14 +14,13 @@ After the survey is complete, the researcher sends the candidate a link to the i
 
 This is a basic application for managing that process.
 
-
 ## Current functionality
 
 The app has two views - one for each role. 
 
 For the researcher, they can visit `/setup` to add coupon codes for their research. Currently there is a single text field where the research can enter a code.
 
-For the candidate, they can visit `/redeem` to redeem a coupon code after the research has been completed. They click 
+For the candidate, they can visit `/redeem` to redeem a coupon code after the research has been completed. They click ????
 
 
 ## Exercise
@@ -30,11 +29,52 @@ Right now the app only supports a single coupon code. We want to extend the app 
 
 - The researcher can visit `/setup` and add several coupon codes.
 - The candidate can visit `/redeem` and issue a unique code every time they click Redeem. 
+  - No idea what this means really, but taking a stab to start the conversation
 - Once redeemed, a coupon code must be marked as redeemed so that it cannot be used again. 
 - The researcher should be able to see which coupon codes have been redeemed, and add additional codes. 
 
 Please fork this repository for your changes, and make clean git commits with your changes.
 
+## How I am approaching the problem
+
+A coupon code like `helloworld` is obfuscated into some unique code for each candidate, these are called `CandidateIncentive`s
+CandidateIncentives can be redeemed from the `/redeem` endpoint
+
+There would be another endpoint for deactivating or ending a campaign which would turn the `Incentive`s off or make them inactive
+
+This seems to make sense in the context of a campaign, whereby there are multiple codes added in bulk to be given to a group of candidates (franchise).
+
+These codes are then obfuscated and used for each candidate as a `CandidateIncentive` record and redeemed from there so the original code is not used.
+
+This would be the same as having a redemptions table for the `Incentive` just named `CandidateIncentive`. The `redemptions#index` view contains the `codes` to be used by the candidate to be redeem and the `redemptions#show` view is the view to redeem the codes.
+
+There are one million ways to implment this and although vague, it's a relatively good exercise. Hopefully this makes a bit of sense!
+
+We could put the redeem functionality on the same page as the list view, but for simiplicity and times sake, it's moved to `/redeem/:code`
+
+## Questions
+
+- What are the researchers creating multiple coupon codes from? Thin air or pasting something in?
+- Not sure why you would issue a unique code when you click redeem aside from a receipt or proof you did research in which why not just track the research being done and mark a boolean column complete or something?
+- As far as redemptions go, supporting multiple redemptions per code makes more sense from a tracking perspective than a single redemption for a code.
+  - It is possible to redeem the code on the Incentive record with a boolean redeemed column and return a randomly generated code, but the code would not be persisted and would not support multiple redemptions (may be outside the scope of the assignment)
+  - We can fix this easily by adding a redeemed column to the `Incentive` and as mentioned return a generated string or persist the generated string on `Incentive`
+
+## TODO's
+
+- [ ] Modify ruby version back to 2.7.1
+
+
+- [x] Receive codes params, iterate and create multiple Incentives
+  - We do want to create multiple incentives here via comma separated list
+- [x] Pass back securerandom.hex version of the code so people do not use the same code
+  - This is going to come from the candidate incentive model instead of the incentive model so we can provide a consumable code to the candidate vs the original code that could be shared between people
+- [x] Add redeemed boolean flag on the CandidateIncentive
+  - Turns out we need to have a separate association for redeemable codes based on the initial code and to make them unique per candidate
+- [x] Add an endpoint for the researcher to see a list of redeemed codes
+  - Show the candidate_redemptions vs redemptions
+
+  - [ ] Outline pros and cons of each implementation and cover most of the questions they will ask in a follow up including not following the strict directions
 
 ## Instructions
 

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,3 +1,9 @@
-class BaseController < ::ActionController::Api
-  skip_before_action :verify_authenticity_token
+module Api
+  class BaseController < ::ActionController::Base
+    # skip_before_action :verify_authenticity_token
+    # protect_from_forgery with: :null_session
+
+    # Never do this in production
+    skip_forgery_protection
+  end
 end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,0 +1,3 @@
+class BaseController < ::ActionController::Api
+  skip_before_action :verify_authenticity_token
+end

--- a/app/controllers/api/incentives_controller.rb
+++ b/app/controllers/api/incentives_controller.rb
@@ -8,8 +8,6 @@ class Api::IncentivesController < ApplicationController
 
   def create
     if update_params[:code].present?
-      data = service.perform
-
       ::Incentive.upsert_all(data, unique_by: :code)
 
       render json: {
@@ -23,10 +21,8 @@ class Api::IncentivesController < ApplicationController
     end
   end
 
-  # TODO : See if update works
   def update
-    data = service.perform
-    incentive.update(data)
+    Incentive.upsert_all(data)
 
     render json: incentive
   end
@@ -39,6 +35,10 @@ class Api::IncentivesController < ApplicationController
 
   def service
     @_service ||= ::Secret::CodeService.new(codes: update_params[:code])
+  end
+
+  def data
+    @_data ||= service.perform
   end
 
   def incentives

--- a/app/controllers/api/incentives_controller.rb
+++ b/app/controllers/api/incentives_controller.rb
@@ -1,21 +1,51 @@
 class Api::IncentivesController < ApplicationController
-
   def index
-    @incentives = Incentive.all
-    
-    render json: @incentives.to_json
+    render json: {
+      incentives: incentives,
+      allCodes: ::Secret::CodeService.all_codes,
+    }, status: :ok
   end
 
-  def update
-    @incentive = Incentive.find(params[:id])
+  def create
+    if update_params[:code].present?
+      data = service.perform
 
-    @incentive.update!(update_params)
-    render json: @incentive.to_json
+      ::Incentive.upsert_all(data, unique_by: :code)
+
+      render json: {
+        incentives: incentives,
+        allCodes: ::Secret::CodeService.all_codes,
+      }, status: :created
+    else
+      render json: {
+        errors: 'Unable to create incentives',
+      }, status: :unprocessable_entity
+    end
+  end
+
+  # TODO : See if update works
+  def update
+    data = service.perform
+    incentive.update(data)
+
+    render json: incentive
   end
 
   private
 
   def update_params
     params.require(:incentive).permit(:code)
+  end
+
+  def service
+    @_service ||= ::Secret::CodeService.new(codes: update_params[:code])
+  end
+
+  def incentives
+    @_incentives ||= Incentive.all
+  end
+
+  def incentive
+    @_incentive ||= Incentive.find(params[:id])
   end
 end

--- a/app/controllers/api/incentives_controller.rb
+++ b/app/controllers/api/incentives_controller.rb
@@ -6,6 +6,12 @@ class Api::IncentivesController < ApplicationController
     }, status: :ok
   end
 
+  def show
+    render json: {
+      incentive: incentive,
+    }, status: :ok
+  end
+
   def create
     if update_params[:code].present?
       ::Incentive.upsert_all(data, unique_by: :code)

--- a/app/controllers/api/redemptions_controller.rb
+++ b/app/controllers/api/redemptions_controller.rb
@@ -1,7 +1,18 @@
 class Api::RedemptionsController < ::Api::BaseController
-  # GET /api/incentives/:incentive_id/redemptions
-  def index
-    render json: { redeemed: redeemed }, status: :ok
+  # POST /api/incentives/:incentive_id/redemptions
+  def create
+    candidate_incentive = candidate_incentives.create(redeemed: true)
+
+    if candidate_incentive.persisted?
+      render json: {
+        candidate_incentive: candidate_incentive,
+        redeemed: redeemed,
+      }, status: :created
+    else
+      render json: {
+        errors: candidate_incentive.errors.messages,
+      }, status: :unprocessable_entity
+    end
   end
 
   private

--- a/app/controllers/api/redemptions_controller.rb
+++ b/app/controllers/api/redemptions_controller.rb
@@ -1,40 +1,42 @@
-class Api::RedemptionsController < ::Api::BaseController
-  # POST /api/incentives/:incentive_id/redemptions
-  def create
-    candidate_incentive = candidate_incentives.create(redeemed: true)
+module Api
+  class RedemptionsController < ::Api::BaseController
+    # POST /api/incentives/:incentive_id/redemptions
+    def create
+      candidate_incentive = candidate_incentives.create(redeemed: true)
 
-    if candidate_incentive.persisted?
-      render json: {
-        candidate_incentive: candidate_incentive,
-        redeemed: redeemed,
-      }, status: :created
-    else
-      render json: {
-        errors: candidate_incentive.errors.messages,
-      }, status: :unprocessable_entity
+      if candidate_incentive.persisted?
+        render json: {
+          candidateIncentive: candidate_incentive,
+          redeemed: redeemed,
+        }, status: :created
+      else
+        render json: {
+          errors: candidate_incentive.errors.messages,
+        }, status: :unprocessable_entity
+      end
     end
-  end
 
-  private
+    private
 
-  # Incentive for the supplied ID
-  #
-  # @return [<Incentive>]
-  def incentive
-    Incentive.find_by!(id: params[:incentive_id])
-  end
+    # Incentive for the supplied ID
+    #
+    # @return [<Incentive>]
+    def incentive
+      Incentive.find_by!(id: params[:incentive_id])
+    end
 
-  # Candidate inventives for the incentive
-  #
-  # @return [ActiveRecord::Collection<CandidateIncentive>]
-  def candidate_incentives
-    incentive.candidate_incentives
-  end
+    # Candidate inventives for the incentive
+    #
+    # @return [ActiveRecord::Collection<CandidateIncentive>]
+    def candidate_incentives
+      incentive.candidate_incentives
+    end
 
-  # The redeemed candidate incentives based on the incentive
-  #
-  # @return [ActiveRecord::Collection<CandidateIncentive>]
-  def redeemed
-    candidate_incentives.redeemed_incentives
+    # The redeemed candidate incentives based on the incentive
+    #
+    # @return [ActiveRecord::Collection<CandidateIncentive>]
+    def redeemed
+      candidate_incentives.redeemed_incentives
+    end
   end
 end

--- a/app/controllers/api/redemptions_controller.rb
+++ b/app/controllers/api/redemptions_controller.rb
@@ -1,11 +1,29 @@
 class Api::RedemptionsController < ::Api::BaseController
+  # GET /api/incentives/:incentive_id/redemptions
   def index
     render json: { redeemed: redeemed }, status: :ok
   end
 
   private
 
+  # Incentive for the supplied ID
+  #
+  # @return [<Incentive>]
+  def incentive
+    Incentive.find_by!(id: params[:incentive_id])
+  end
+
+  # Candidate inventives for the incentive
+  #
+  # @return [ActiveRecord::Collection<CandidateIncentive>]
+  def candidate_incentives
+    incentive.candidate_incentives
+  end
+
+  # The redeemed candidate incentives based on the incentive
+  #
+  # @return [ActiveRecord::Collection<CandidateIncentive>]
   def redeemed
-    Incentive.redeemed
+    candidate_incentives.redeemed_incentives
   end
 end

--- a/app/controllers/api/redemptions_controller.rb
+++ b/app/controllers/api/redemptions_controller.rb
@@ -1,0 +1,11 @@
+class Api::RedemptionsController < ::Api::BaseController
+  def index
+    render json: { redeemed: redeemed }, status: :ok
+  end
+
+  private
+
+  def redeemed
+    Incentive.redeemed
+  end
+end

--- a/app/controllers/candidates_controller.rb
+++ b/app/controllers/candidates_controller.rb
@@ -1,6 +1,0 @@
-class CandidatesController < ApplicationController
-
-  def show
-    
-  end
-end

--- a/app/controllers/redemptions_controller.rb
+++ b/app/controllers/redemptions_controller.rb
@@ -1,0 +1,12 @@
+class RedemptionsController < ApplicationController
+  # For the candidate, they can visit `/redeem` to redeem a coupon code after the research has been completed. They click
+  def index
+    render 'index', locals: {}
+  end
+
+  private
+
+  def permitted_params
+    params.require(:incentive)
+  end
+end

--- a/app/controllers/redemptions_controller.rb
+++ b/app/controllers/redemptions_controller.rb
@@ -1,12 +1,21 @@
 class RedemptionsController < ApplicationController
   # For the candidate, they can visit `/redeem` to redeem a coupon code after the research has been completed. They click
   def index
-    render 'index', locals: {}
+    render 'index', locals: { incentives: incentives }
+  end
+
+  def show
+    render 'show', locals: { incentive: incentive }
   end
 
   private
 
-  def permitted_params
-    params.require(:incentive)
+  # Scope this and fix routes
+  def incentives
+    @_incentives ||= Incentive.all
+  end
+
+  def incentive
+    @_incentive ||= incentives.find_by(code: params[:code])
   end
 end

--- a/app/controllers/researchers_controller.rb
+++ b/app/controllers/researchers_controller.rb
@@ -1,6 +1,0 @@
-class ResearchersController < ApplicationController
-
-  def show
-    
-  end
-end

--- a/app/controllers/setups_controller.rb
+++ b/app/controllers/setups_controller.rb
@@ -4,19 +4,7 @@ class SetupsController < ApplicationController
     render 'index', locals: { incentives: incentives }
   end
 
-  def create
-
-  end
-
   private
-
-  def permitted_params
-    params.permit(:codes)
-  end
-
-  def codes
-    permitted_params[:codes]
-  end
 
   def incentives
     Incentive.all

--- a/app/controllers/setups_controller.rb
+++ b/app/controllers/setups_controller.rb
@@ -1,0 +1,24 @@
+class SetupsController < ApplicationController
+  # For the researcher, they can visit `/setup` to add coupon codes for their research. Currently there is a single text field where the research can enter a code.
+  def index
+    render 'index', locals: { incentives: incentives }
+  end
+
+  def create
+
+  end
+
+  private
+
+  def permitted_params
+    params.permit(:codes)
+  end
+
+  def codes
+    permitted_params[:codes]
+  end
+
+  def incentives
+    Incentive.all
+  end
+end

--- a/app/javascript/api/endpoints.ts
+++ b/app/javascript/api/endpoints.ts
@@ -7,7 +7,11 @@ export const getIncentives = async (): Promise<Incentive[]> => {
 };
 
 export const getIncentive = async (id: number): Promise<Incentive[]> => {
-  const resp = await fetch(`/api/incentives/${id}`);
+  const resp = await fetch(`/api/incentives/${id}`, {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json' },
+  });
+
   if (resp.ok) {
     return await resp.json();
   }
@@ -17,7 +21,7 @@ export const getIncentive = async (id: number): Promise<Incentive[]> => {
 export const createIncentives = async (params: Partial<Incentive>): Promise<Incentive> => {
   const resp = await fetch('/api/incentives', {
     method: 'POST',
-    headers: {'Content-Type': 'application/json'},
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(params),
   });
   if (resp.ok) {
@@ -29,7 +33,7 @@ export const createIncentives = async (params: Partial<Incentive>): Promise<Ince
 export const updateIncentive = async (id: number, params: Partial<Incentive>): Promise<Incentive> => {
   const resp = await fetch(`/api/incentives/${id}`, {
     method: 'PUT',
-    headers: {'Content-Type': 'application/json'},
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(params),
   });
   if (resp.ok) {
@@ -38,10 +42,10 @@ export const updateIncentive = async (id: number, params: Partial<Incentive>): P
   return null;
 };
 
-export const createRedemption = async (id: number): Promise<CandidateIncentive> => {
-  const resp = await fetch(`/api/incentive/${}/redemptions/${id}`, {
+export const createRedemption = async (id: number, params: Partial<CandidateIncentive>): Promise<CandidateIncentive> => {
+  const resp = await fetch(`/api/incentives/${id}/redemptions`, {
     method: 'POST',
-    headers: {'Content-Type': 'application/json'},
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(params),
   });
   if (resp.ok) {

--- a/app/javascript/api/endpoints.ts
+++ b/app/javascript/api/endpoints.ts
@@ -1,6 +1,13 @@
-
 export const getIncentives = async (): Promise<Incentive[]> => {
   const resp = await fetch('/api/incentives');
+  if (resp.ok) {
+    return await resp.json();
+  }
+  return null;
+};
+
+export const getIncentive = async (id: number): Promise<Incentive[]> => {
+  const resp = await fetch(`/api/incentives/${id}`);
   if (resp.ok) {
     return await resp.json();
   }
@@ -30,3 +37,15 @@ export const updateIncentive = async (id: number, params: Partial<Incentive>): P
   }
   return null;
 };
+
+export const createRedemption = async (id: number): Promise<CandidateIncentive> => {
+  const resp = await fetch(`/api/incentive/${}/redemptions/${id}`, {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(params),
+  });
+  if (resp.ok) {
+    return await resp.json();
+  }
+  return null;
+}

--- a/app/javascript/api/endpoints.ts
+++ b/app/javascript/api/endpoints.ts
@@ -7,6 +7,18 @@ export const getIncentives = async (): Promise<Incentive[]> => {
   return null;
 };
 
+export const createIncentives = async (params: Partial<Incentive>): Promise<Incentive> => {
+  const resp = await fetch('/api/incentives', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(params),
+  });
+  if (resp.ok) {
+    return await resp.json();
+  }
+  return null;
+};
+
 export const updateIncentive = async (id: number, params: Partial<Incentive>): Promise<Incentive> => {
   const resp = await fetch(`/api/incentives/${id}`, {
     method: 'PUT',

--- a/app/javascript/components/CandidateApp/CandidateApp.tsx
+++ b/app/javascript/components/CandidateApp/CandidateApp.tsx
@@ -1,26 +1,33 @@
 import * as React from 'react';
 import { useEffect, useState } from 'react';
-import { getIncentives } from '@api/endpoints';
+import { getIncentive } from '@api/endpoints';
 import { Redeem } from './Redeem';
 
+// Candidate app is responsible for the redemptions of the code
 export const CandidateApp: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [data, setData] = useState<Incentive[]>(null);
 
   useEffect(() => {
-    getIncentives()
-      .then(incentives => {
-        setData(incentives);
+    const el = document.getElementById('CandidateApp')
+    const { id } = el.dataset
+
+    getIncentive(id)
+      .then(incentive => {
+        setData(incentive);
         setLoading(false);
       });
   }, []);
 
   return (
     <div className="px-12 py-6">
-      <h1 className="text-2xl font-bold mb-6">Redeem incentive</h1>
+      <h1 className="text-2xl font-bold mb-6">Redeem Incentive</h1>
+      <p>
+        In order to receive a candidate redemption code for participating in research,
+        &nbsp;you'll need to redeem the incentive!
+      </p>
 
       {loading && <span>Loading...</span>}
-
       {!loading && <Redeem data={data} />}
     </div>
   );

--- a/app/javascript/components/CandidateApp/Redeem.tsx
+++ b/app/javascript/components/CandidateApp/Redeem.tsx
@@ -1,14 +1,32 @@
 import * as React from 'react';
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
+import { createRedemption } from '@api/endpoints';
 
 interface Props {
   data: Incentive[];
 }
 export const Redeem: React.FC<Props> = ({ data }) => {
   const [redeemed, setRedeemed] = useState(false);
+  const [message, setMessage] = useState('');
+  const [redemption, setRedemption] = useState(null);
+  const [candidateIncentiveValue, setCandidateIncentiveValue] = useState(null);
+
+  const { incentive } = data;
+  const { code, id } = incentive
 
   async function handleClickRedeem() {
-    setRedeemed(true);
+    setRedeemed(false);
+    const redemption = await createRedemption(id, code);
+
+    if (redemption) {
+      const { candidateIncentive } = redemption;
+      setMessage('Successfully redeemed!');
+      setRedemption(candidateIncentive);
+      setTimeout(() => setMessage(''), 1500);
+      setRedeemed(true);
+    } else {
+      setMessage('An error occured');
+    }
   }
 
   return (
@@ -25,7 +43,7 @@ export const Redeem: React.FC<Props> = ({ data }) => {
 
       {redeemed && (
         <div className="py-4 text-green-600 italic">
-          Your code is: {data[0].code}. Thanks for participating in our research!
+          Your code is: {redemption.code}. Thanks for participating in our research!
         </div>
       )}
     </div>

--- a/app/javascript/components/CandidateApp/Redeem.tsx
+++ b/app/javascript/components/CandidateApp/Redeem.tsx
@@ -12,7 +12,7 @@ export const Redeem: React.FC<Props> = ({ data }) => {
   const [candidateIncentiveValue, setCandidateIncentiveValue] = useState(null);
 
   const { incentive } = data;
-  const { code, id } = incentive
+  const { code, id } = incentive;
 
   async function handleClickRedeem() {
     setRedeemed(false);

--- a/app/javascript/components/CandidatesApp/CandidatesApp.tsx
+++ b/app/javascript/components/CandidatesApp/CandidatesApp.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { useEffect, useState, useRef } from 'react';
+import { getIncentives } from '@api/endpoints';
+
+// Candidate app is responsible for the redemptions of the code
+export const CandidatesApp: React.FC = () => {
+  const [loading, setLoading] = useState(true);
+  const [data, setData] = useState<Incentive[]>(null);
+  // const input = useRef(null);
+
+  useEffect(() => {
+    getIncentives()
+      .then(incentives => {
+        setData(incentives.incentives);
+        setLoading(false);
+      });
+  }, []);
+
+  const copyCodeToClipboard = () => {
+    // TODO : Figure out copy functionality with ref hooks
+    // input.current.focus()
+    // document.execCommand('copy')
+  }
+
+  console.log(data, 'data inside of candidates app')
+
+  return (
+    <div className="px-12 py-6">
+      <h1 className="text-2xl font-bold mb-6">Incentive Codes</h1>
+
+      { loading && <span>Loading...</span> }
+
+      {
+        !loading && data !== undefined && data.map((el) => (
+          <span
+            key={el.code}
+            className="flex space-x-2 pb-4"
+          >
+            <input
+              className="text-xl border"
+              defaultValue={el.code}
+              name={el.code}
+            />
+            <button
+              className="hover:bg-gray-100 bg-gray-200 rounded-md px-4 py-2"
+              onClick={() => this.copyCodeToClipboard()}>
+              Copy
+            </button>
+            <button
+              className="hover:bg-gray-100 bg-gray-200 rounded-md px-4 py-2"
+              onClick={() => window.location = `/redeem/${el.code}`}>
+              Redeem
+            </button>
+          </span>
+        ))
+      }
+    </div>
+  );
+};

--- a/app/javascript/components/CandidatesApp/CandidatesApp.tsx
+++ b/app/javascript/components/CandidatesApp/CandidatesApp.tsx
@@ -17,12 +17,10 @@ export const CandidatesApp: React.FC = () => {
   }, []);
 
   const copyCodeToClipboard = () => {
-    // TODO : Figure out copy functionality with ref hooks
+    console.log('TODO : Implement this with refHooks!')
     // input.current.focus()
     // document.execCommand('copy')
   }
-
-  console.log(data, 'data inside of candidates app')
 
   return (
     <div className="px-12 py-6">

--- a/app/javascript/components/CandidatesApp/index.ts
+++ b/app/javascript/components/CandidatesApp/index.ts
@@ -1,0 +1,1 @@
+export { CandidatesApp } from './CandidatesApp'

--- a/app/javascript/components/ResearcherApp/IncentiveForm.tsx
+++ b/app/javascript/components/ResearcherApp/IncentiveForm.tsx
@@ -1,19 +1,19 @@
 import * as React from 'react';
 import { useState } from 'react';
-import { updateIncentive } from '@api/endpoints';
+import { createIncentives } from '@api/endpoints';
 
 interface Props {
   data: Incentive[];
 }
-export const IncentiveForm: React.FC<Props> = ({ data }) => {
+export const IncentiveForm: React.FC<Props> = ({ allCodes }) => {
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState('');
-  const [inputValue, setInputValue] = useState(data[0].code);
+  const [inputValue, setInputValue] = useState(allCodes)
 
   async function handleClickSave() {
     setSaving(true);
-    const incentive = await updateIncentive(data[0].id, { code: inputValue });
-    if (incentive) {
+    const incentives = await createIncentives({ code: inputValue });
+    if (incentives) {
       setMessage('Successfully updated!');
       setTimeout(() => setMessage(''), 2000);
     } else {
@@ -25,10 +25,11 @@ export const IncentiveForm: React.FC<Props> = ({ data }) => {
   return (
     <div>
       <div className="flex space-x-2 pb-4">
-        <input
+        <textarea
+          rows="5"
+          cols="50"
           disabled={saving}
           className="text-xl border"
-          type="text"
           name="incentive_code"
           value={inputValue}
           onChange={e => setInputValue(e.currentTarget.value)}

--- a/app/javascript/components/ResearcherApp/ResearcherApp.tsx
+++ b/app/javascript/components/ResearcherApp/ResearcherApp.tsx
@@ -5,12 +5,13 @@ import { IncentiveForm } from './IncentiveForm';
 
 export const ResearcherApp: React.FC = () => {
   const [loading, setLoading] = useState(true);
-  const [data, setData] = useState<Incentive[]>(null);
+  // const [data, setData] = useState<Incentive[]>(null);
+  const [allCodes, setAllCodes] = useState<Incentive[]>(null);
 
   useEffect(() => {
     getIncentives()
       .then(incentives => {
-        setData(incentives);
+        setAllCodes(incentives.allCodes);
         setLoading(false);
       });
   }, []);
@@ -18,11 +19,10 @@ export const ResearcherApp: React.FC = () => {
   return (
     <div className="px-12 py-6">
       <h1 className="text-2xl font-bold mb-6">Setup incentive</h1>
-      <p className="mb-4">Enter the coupon code for the candidate to receive:</p>
+      <p className="mb-4">Enter the coupon codes for the candidate to receive: (You separate multiple codes with commas!)</p>
 
-      {loading && <span>Loading...</span>}
-
-      {!loading && <IncentiveForm data={data} />}
+      { loading && <span>Loading...</span> }
+      { !loading && <IncentiveForm allCodes={allCodes} /> }
     </div>
   );
 };

--- a/app/javascript/components/types.d.ts
+++ b/app/javascript/components/types.d.ts
@@ -7,3 +7,7 @@ interface Model {
 interface Incentive extends Model {
   code: string;
 }
+
+interface CandidateIncentive extends Model {
+  code: string;
+}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,13 +10,15 @@ require("channels")
 
 import { ResearcherApp } from  'components/ResearcherApp'
 import { CandidateApp } from  'components/CandidateApp'
+import { CandidatesApp } from 'components/CandidatesApp'
+
 import { mount, docReady } from 'utils'
 
 docReady(() => {
   mount('ResearcherApp', ResearcherApp)
   mount('CandidateApp', CandidateApp)
+  mount('CandidatesApp', CandidatesApp)
 })
-
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/app/models/candidate_incentive.rb
+++ b/app/models/candidate_incentive.rb
@@ -1,0 +1,16 @@
+# Candidate incentive is the actual redemption coupon displayed to the end user for redemption
+# This allows for a code to be set per user and redeemed without the initial code being shared between users
+class CandidateIncentive < ApplicationRecord
+  belongs_to :incentive
+  before_save :set_code, if: -> { code.nil? }
+
+  scope :redeemed_incentives, -> { where(redeemed: true) }
+
+  validates :redeemed, inclusion: { in: [true, false] }, presence: true
+
+  def set_code
+    return if code.present?
+
+    self[:code] = SecureRandom.hex(8)
+  end
+end

--- a/app/models/candidate_incentive.rb
+++ b/app/models/candidate_incentive.rb
@@ -6,7 +6,7 @@ class CandidateIncentive < ApplicationRecord
 
   scope :redeemed_incentives, -> { where(redeemed: true) }
 
-  validates :redeemed, inclusion: { in: [true, false] }, presence: true
+  validates :redeemed, inclusion: { in: [true, false] }
 
   def set_code
     return if code.present?

--- a/app/models/incentive.rb
+++ b/app/models/incentive.rb
@@ -1,5 +1,7 @@
 class Incentive < ApplicationRecord
-  scope :redeemed, -> { where(redeemed: true) }
+  scope :redeemed_incentives, -> { where(redeemed: true) }
 
-
+  validates :redeemed,
+    inclusion: { in: [true, false] },
+    presence: true
 end

--- a/app/models/incentive.rb
+++ b/app/models/incentive.rb
@@ -1,4 +1,5 @@
 # Incentive is the coupon set by the researcher (person who is creating the campaign or whatever resoruce)
 class Incentive < ApplicationRecord
   has_many :candidate_incentives, dependent: :destroy
+  validates :code, presence: true, uniqueness: true
 end

--- a/app/models/incentive.rb
+++ b/app/models/incentive.rb
@@ -1,2 +1,5 @@
 class Incentive < ApplicationRecord
+  scope :redeemed, -> { where(redeemed: true) }
+
+
 end

--- a/app/models/incentive.rb
+++ b/app/models/incentive.rb
@@ -1,7 +1,4 @@
+# Incentive is the coupon set by the researcher (person who is creating the campaign or whatever resoruce)
 class Incentive < ApplicationRecord
-  scope :redeemed_incentives, -> { where(redeemed: true) }
-
-  validates :redeemed,
-    inclusion: { in: [true, false] },
-    presence: true
+  has_many :candidate_incentives, dependent: :destroy
 end

--- a/app/services/code_generation_service.rb
+++ b/app/services/code_generation_service.rb
@@ -1,0 +1,24 @@
+::CODES = %w(
+  8c0dac1425a9
+  8330e3608b67
+  78001f2b7515
+  da140d87d832
+  e6dbd8ce0e9b
+  241275fafb3a
+  bed98a242d5f
+  17d76d028fe1
+  e542f0076e54
+  62250fe16e6f
+)
+
+class CodeGenerationService
+  def self.perform
+    ::CODES.each do |code|
+      incentive = Incentive.create(code: code)
+
+      4.times do |i|
+        incentive.candidate_incentives.create!
+      end
+    end
+  end
+end

--- a/app/services/secret/code_service.rb
+++ b/app/services/secret/code_service.rb
@@ -11,12 +11,8 @@ module Secret
 
     # Return the single code to be updated otherwise map and return the array of hashes to be bulk inserted
     def perform
-      if split_codes.count.eql?(1)
+      split_codes.map do |code|
         { code: code }.merge(timestamps)
-      else
-        split_codes.map do |code|
-          { code: code }.merge(timestamps)
-        end
       end
     end
 
@@ -26,7 +22,6 @@ module Secret
 
     private
 
-    attr_reader :split_codes,
-                :timestamps
+    attr_reader :split_codes, :timestamps
   end
 end

--- a/app/services/secret/code_service.rb
+++ b/app/services/secret/code_service.rb
@@ -1,0 +1,32 @@
+module Secret
+  class CodeService
+    def initialize(codes:)
+      @codes = codes
+      @split_codes = codes.gsub(' ', '').split(',')
+      @timestamps = {
+        created_at: Time.zone.now,
+        updated_at: Time.zone.now,
+      }
+    end
+
+    # Return the single code to be updated otherwise map and return the array of hashes to be bulk inserted
+    def perform
+      if split_codes.count.eql?(1)
+        { code: code }.merge(timestamps)
+      else
+        split_codes.map do |code|
+          { code: code }.merge(timestamps)
+        end
+      end
+    end
+
+    def self.all_codes
+      ::Incentive.all.map(&:code).join(', ')
+    end
+
+    private
+
+    attr_reader :split_codes,
+                :timestamps
+  end
+end

--- a/app/views/candidates/show.html.erb
+++ b/app/views/candidates/show.html.erb
@@ -1,1 +1,0 @@
-<div id="CandidateApp">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,7 +1,17 @@
-<h1> GQ Coding Exercise: Incentive Redeemer </h1>
+<h1>
+  <span style="color: #594FEC; font-weight: bold;">GQ</span>
+  <span style="font-weight: bold;">&nbsp;Coding Exercise:</span>
+  &nbsp;Incentive Redeemer
+</h1>
+
+<br />
+
 <div>
-<%= link_to 'Setup', setup_path %>
-</div>
-<div>
-<%= link_to 'Redeem', redeem_path %>
+  <div class="pb-4">
+    <%= link_to 'Redeem', redeem_path, class: "hover:bg-green-100 bg-green-200 rounded-md px-4 py-2" %>
+  </div>
+
+  <div class="pb-4">
+    <%= link_to 'Setup', setup_path, class: "hover:bg-green-100 bg-green-200 rounded-md px-4 py-2" %>
+  </div>
 </div>

--- a/app/views/redemptions/index.html.erb
+++ b/app/views/redemptions/index.html.erb
@@ -1,0 +1,1 @@
+<div id="CandidateApp">

--- a/app/views/redemptions/index.html.erb
+++ b/app/views/redemptions/index.html.erb
@@ -1,1 +1,1 @@
-<div id="CandidateApp">
+<div id="CandidatesApp">

--- a/app/views/redemptions/show.html.erb
+++ b/app/views/redemptions/show.html.erb
@@ -1,1 +1,1 @@
-<div id="CandidateApp">
+<div id="CandidateApp" data-id="<%= incentive.id %>">

--- a/app/views/redemptions/show.html.erb
+++ b/app/views/redemptions/show.html.erb
@@ -1,0 +1,1 @@
+<div id="CandidateApp">

--- a/app/views/researchers/show.html.erb
+++ b/app/views/researchers/show.html.erb
@@ -1,1 +1,0 @@
-<div id="ResearcherApp">

--- a/app/views/setups/index.html.erb
+++ b/app/views/setups/index.html.erb
@@ -1,0 +1,1 @@
+<div id="ResearcherApp">

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,9 @@ module GqTakeHome
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+
+    %w[services].each do |dir|
+      config.autoload_paths << Rails.root.join('app', dir, '**/**/*.rb')
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   namespace :api, defaults: {format: :json} do
-    resources :incentives, only: [:index, :create] do
+    resources :incentives, only: [:index, :show, :create] do
       resources :redemptions, only: [:create]
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   namespace :api, defaults: {format: :json} do
     resources :incentives
+    resources :redemptions, only: [:index]
   end
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   get :redeem, to: 'candidates#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,12 @@
 Rails.application.routes.draw do
   namespace :api, defaults: {format: :json} do
-    resources :incentives, only: [:index, :update]
-    resources :redemptions, only: [:index]
+    resources :incentives, only: [:index, :create] do
+      resources :redemptions, only: [:index]
+    end
   end
 
-  get :redeem, to: 'candidates#show'
-  get :setup, to: 'researchers#show'
+  get :redeem, to: 'redemptions#index'
+  get :setup, to: 'setups#index'
+
   root to: 'home#index'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,9 @@
 Rails.application.routes.draw do
   namespace :api, defaults: {format: :json} do
-    resources :incentives
+    resources :incentives, only: [:index, :update]
     resources :redemptions, only: [:index]
   end
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+
   get :redeem, to: 'candidates#show'
   get :setup, to: 'researchers#show'
   root to: 'home#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,13 @@
 Rails.application.routes.draw do
   namespace :api, defaults: {format: :json} do
     resources :incentives, only: [:index, :create] do
-      resources :redemptions, only: [:index]
+      resources :redemptions, only: [:create]
     end
   end
 
-  get :redeem, to: 'redemptions#index'
-  get :setup, to: 'setups#index'
+  get '/redeem', to: 'redemptions#index', as: :redeem
+  get '/redeem/:code', to: 'redemptions#show', as: :redemption
+  get '/setup', to: 'setups#index', as: :setup
 
   root to: 'home#index'
 end

--- a/db/migrate/20210606053509_create_incentives.rb
+++ b/db/migrate/20210606053509_create_incentives.rb
@@ -5,5 +5,7 @@ class CreateIncentives < ActiveRecord::Migration[6.0]
 
       t.timestamps
     end
+
+    add_index :incentives, :code, unique: true
   end
 end

--- a/db/migrate/20210607012944_create_default_incentive.rb
+++ b/db/migrate/20210607012944_create_default_incentive.rb
@@ -1,5 +1,5 @@
 class CreateDefaultIncentive < ActiveRecord::Migration[6.0]
   def change
-    Incentive.create(code: "8xWnvk6a")
+    # Incentive.create(code: "8xWnvk6a")
   end
 end

--- a/db/migrate/20210712193430_add_redeemed_boolean_to_incentives.rb
+++ b/db/migrate/20210712193430_add_redeemed_boolean_to_incentives.rb
@@ -1,0 +1,5 @@
+class AddRedeemedBooleanToIncentives < ActiveRecord::Migration[6.0]
+  def change
+    add_column :incentives, :redeemed, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20210712193430_add_redeemed_boolean_to_incentives.rb
+++ b/db/migrate/20210712193430_add_redeemed_boolean_to_incentives.rb
@@ -1,5 +1,0 @@
-class AddRedeemedBooleanToIncentives < ActiveRecord::Migration[6.0]
-  def change
-    add_column :incentives, :redeemed, :boolean, default: false, null: false
-  end
-end

--- a/db/migrate/20210712195136_create_candidate_incentives.rb
+++ b/db/migrate/20210712195136_create_candidate_incentives.rb
@@ -1,0 +1,11 @@
+class CreateCandidateIncentives < ActiveRecord::Migration[6.0]
+  def change
+    create_table :candidate_incentives do |t|
+      t.belongs_to :incentive, null: false, foreign_key: true
+      t.string :code
+      t.boolean :redeemed, default: false, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210712195136_create_candidate_incentives.rb
+++ b/db/migrate/20210712195136_create_candidate_incentives.rb
@@ -7,5 +7,7 @@ class CreateCandidateIncentives < ActiveRecord::Migration[6.0]
 
       t.timestamps
     end
+
+    add_index :candidate_incentives, :code, unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define(version: 2021_07_12_195136) do
     t.boolean "redeemed", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["code"], name: "index_candidate_incentives_on_code", unique: true
     t.index ["incentive_id"], name: "index_candidate_incentives_on_incentive_id"
   end
 
@@ -25,6 +26,7 @@ ActiveRecord::Schema.define(version: 2021_07_12_195136) do
     t.string "code"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["code"], name: "index_incentives_on_code", unique: true
   end
 
   add_foreign_key "candidate_incentives", "incentives"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_07_012944) do
+ActiveRecord::Schema.define(version: 2021_07_12_195136) do
+
+  create_table "candidate_incentives", force: :cascade do |t|
+    t.integer "incentive_id", null: false
+    t.string "code"
+    t.boolean "redeemed", default: false, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["incentive_id"], name: "index_candidate_incentives_on_incentive_id"
+  end
 
   create_table "incentives", force: :cascade do |t|
     t.string "code"
@@ -18,4 +27,5 @@ ActiveRecord::Schema.define(version: 2021_06_07_012944) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  add_foreign_key "candidate_incentives", "incentives"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,1 +1,5 @@
-Incentive.create(code: "8xWnvk6a")
+::CODES = %w(8xWnvk6a)
+
+::CODES.each do |code|
+  Incentive.create(code: code)
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,1 @@
-::CODES = %w(8xWnvk6a)
-
-::CODES.each do |code|
-  incentive = Incentive.create(code: code)
-
-  4.times do |i|
-    incentive.candidate_incentives.create!
-  end
-end
+CodeGenerationService.perform

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,1 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+Incentive.create(code: "8xWnvk6a")

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,9 @@
 ::CODES = %w(8xWnvk6a)
 
 ::CODES.each do |code|
-  Incentive.create(code: code)
+  incentive = Incentive.create(code: code)
+
+  4.times do |i|
+    incentive.candidate_incentives.create!
+  end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "gq_take_home",
   "private": true,
+  "scripts": {
+    "start": "./bin/webpack-dev-server"
+  },
   "dependencies": {
     "@babel/preset-react": "^7.13.13",
     "@babel/preset-typescript": "^7.13.0",

--- a/test/fixtures/candidate_incentives.yml
+++ b/test/fixtures/candidate_incentives.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  incentive: one
+  code: MyString
+
+two:
+  incentive: two
+  code: MyString

--- a/test/models/candidate_incentive_test.rb
+++ b/test/models/candidate_incentive_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CandidateIncentiveTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Here is the PR for adding the readme functionality to a loose degree.

In my eyes this would be considered a spike and would require a follow up with someone to gather more thorough requirements, specifically around extensibility and making sure the requirements are understood completely.

The functionality as implemented is a little bit different than the outlined requirements, but allows for storing multiple `Incentive`s and issueing multiple "redemptions" per `Incentive`.

I see this as a bit more straightforward than having a boolean column on the `Incentive` and setting a status. The upside of this would be being able to pause a campaign and unpause and create another "redemption" or `CandidateIncentive` while maintaining the same original code!

Functionality has also been added to support both single entry and comma separated values in the initial multiple `Incentive` screen.

**Setup Code Screen:**

<img width="909" alt="Screen Shot 2021-07-14 at 1 32 28 PM" src="https://user-images.githubusercontent.com/3254361/125681979-917394a2-eaec-4b66-8758-78a369a54c90.png">

**Redemption List for multiple Codes:**

<img width="854" alt="Screen Shot 2021-07-14 at 1 18 26 PM" src="https://user-images.githubusercontent.com/3254361/125682423-2e48388c-7b42-4c1c-9e9f-a5dea07b68ba.png">

**Redemption view:**

<img width="1215" alt="Screen Shot 2021-07-14 at 1 16 55 PM" src="https://user-images.githubusercontent.com/3254361/125680001-9a653ad8-a8d8-4c0b-8b87-9eace2952ddf.png">

The home screen has been **spruced** up a bit to engage both candidates and researchers!

<img width="680" alt="Screen Shot 2021-07-14 at 1 34 06 PM" src="https://user-images.githubusercontent.com/3254361/125682196-22c58c30-50b2-4267-bcae-29f4fba4797a.png">

Some notes have been added to the readme with general thoughts and that is all. Look forward to chatting a bit about this!