### PR TITLE
Multiple codes

### DIFF
--- a/app/controllers/api/incentives_controller.rb
+++ b/app/controllers/api/incentives_controller.rb
@@ -1,21 +1,39 @@
 class Api::IncentivesController < ApplicationController
 
   def index
-    @incentives = Incentive.all
+    @incentives = Incentive.order(created_at: :desc)
     
     render json: @incentives.to_json
   end
 
-  def update
-    @incentive = Incentive.find(params[:id])
+  def redeem
+    @incentive = Incentive.find(
+      Incentive.where(redeemed: false).pluck(:id).shuffle.first
+    )
+    @incentive.update(redeemed: true)
 
-    @incentive.update!(update_params)
     render json: @incentive.to_json
   end
 
+  def create
+    @incentive = Incentive.create(create_params)
+    render json: @incentive.to_json
+  end
+
+  # def update
+  #   @incentive = Incentive.find(params[:id])
+
+  #   @incentive.update!(update_params)
+  #   render json: @incentive.to_json
+  # end
+
   private
 
-  def update_params
+  def create_params
     params.require(:incentive).permit(:code)
   end
+
+  # def update_params
+  #   params.require(:incentive).permit(:code)
+  # end
 end

--- a/app/controllers/api/incentives_controller.rb
+++ b/app/controllers/api/incentives_controller.rb
@@ -17,6 +17,9 @@ class Api::IncentivesController < ApplicationController
 
   def create
     @incentive = Incentive.create(create_params)
+    if @incentive.id == nil
+      raise exception
+    end
     render json: @incentive.to_json
   end
 

--- a/app/controllers/api/incentives_controller.rb
+++ b/app/controllers/api/incentives_controller.rb
@@ -16,10 +16,7 @@ class Api::IncentivesController < ApplicationController
   end
 
   def create
-    @incentive = Incentive.create(create_params)
-    if @incentive.id == nil
-      raise exception
-    end
+    @incentive = Incentive.create!(create_params)
     render json: @incentive.to_json
   end
 

--- a/app/javascript/api/endpoints.ts
+++ b/app/javascript/api/endpoints.ts
@@ -7,9 +7,19 @@ export const getIncentives = async (): Promise<Incentive[]> => {
   return null;
 };
 
-export const updateIncentive = async (id: number, params: Partial<Incentive>): Promise<Incentive> => {
-  const resp = await fetch(`/api/incentives/${id}`, {
-    method: 'PUT',
+export const redeemIncentive = async (): Promise<Incentive[]> => {
+  const resp = await fetch('/api/incentives/redeem');
+  if (resp.ok) {
+    return await resp.json();
+  }
+  return null;
+};
+
+
+
+export const createIncentive = async (params: Partial<Incentive>): Promise<Incentive> => {
+  const resp = await fetch(`/api/incentives`, {
+    method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify(params),
   });

--- a/app/javascript/api/endpoints.ts
+++ b/app/javascript/api/endpoints.ts
@@ -7,7 +7,7 @@ export const getIncentives = async (): Promise<Incentive[]> => {
   return null;
 };
 
-export const redeemIncentive = async (): Promise<Incentive[]> => {
+export const redeemIncentive = async (): Promise<Incentive> => {
   const resp = await fetch('/api/incentives/redeem');
   if (resp.ok) {
     return await resp.json();

--- a/app/javascript/components/CandidateApp/CandidateApp.tsx
+++ b/app/javascript/components/CandidateApp/CandidateApp.tsx
@@ -1,27 +1,18 @@
 import * as React from 'react';
 import { useEffect, useState } from 'react';
-import { getIncentives } from '@api/endpoints';
+import { redeemIncentive } from '@api/endpoints';
 import { Redeem } from './Redeem';
 
 export const CandidateApp: React.FC = () => {
-  const [loading, setLoading] = useState(true);
-  const [data, setData] = useState<Incentive[]>(null);
-
-  useEffect(() => {
-    getIncentives()
-      .then(incentives => {
-        setData(incentives);
-        setLoading(false);
-      });
-  }, []);
+  // const [loading, setLoading] = useState(true);
 
   return (
     <div className="px-12 py-6">
       <h1 className="text-2xl font-bold mb-6">Redeem incentive</h1>
 
-      {loading && <span>Loading...</span>}
+      {/* {loading && <span>Loading...</span>} */}
 
-      {!loading && <Redeem data={data} />}
+      <Redeem />
     </div>
   );
 };

--- a/app/javascript/components/CandidateApp/Redeem.tsx
+++ b/app/javascript/components/CandidateApp/Redeem.tsx
@@ -1,21 +1,35 @@
 import * as React from 'react';
 import { useState } from 'react';
+import { redeemIncentive } from '@api/endpoints';
 
-interface Props {
-  data: Incentive[];
-}
-export const Redeem: React.FC<Props> = ({ data }) => {
+export const Redeem: React.FC<Props> = () => {
   const [redeemed, setRedeemed] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [data, setData] = useState<Incentive>(null);
+  const [error, setError] = useState("")
+
 
   async function handleClickRedeem() {
-    setRedeemed(true);
+    setLoading(true);
+    redeemIncentive()
+      .then(incentive => {
+        if (incentive === null) {
+          throw new Error("null")
+        }
+        setData(incentive);
+        setRedeemed(true);
+        setLoading(false);
+      }).catch((err) => {
+        setError("Something went wrong")
+        setLoading(false);
+      });
   }
 
   return (
     <div>
       <div className="pb-4">
         <button
-          disabled={redeemed}
+          disabled={redeemed || loading}
           className="hover:bg-gray-100 bg-gray-200 rounded-md px-4 py-2"
           onClick={handleClickRedeem}
         >
@@ -23,9 +37,15 @@ export const Redeem: React.FC<Props> = ({ data }) => {
         </button>
       </div>
 
+      {error && (
+        <div className="py-4 text-red-600 italic">
+          {error}
+        </div>
+      )}
+
       {redeemed && (
         <div className="py-4 text-green-600 italic">
-          Your code is: {data[0].code}. Thanks for participating in our research!
+          Your code is: {data.code}. Thanks for participating in our research!
         </div>
       )}
     </div>

--- a/app/javascript/components/ResearcherApp/IncentiveForm.tsx
+++ b/app/javascript/components/ResearcherApp/IncentiveForm.tsx
@@ -3,8 +3,9 @@ import { useState } from 'react';
 import { createIncentive } from '@api/endpoints';
 
 interface Props {
+  updateList(incentive: Incentive): void;
 }
-export const IncentiveForm: React.FC<Props> = () => {
+export const IncentiveForm: React.FC<Props> = ({ updateList }) => {
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState('');
   const [inputValue, setInputValue] = useState("");
@@ -13,9 +14,10 @@ export const IncentiveForm: React.FC<Props> = () => {
     setSaving(true);
     const incentive = await createIncentive({ code: inputValue });
     if (incentive) {
-      setMessage('Successfully updated!');
+      setMessage('Successfully created!');
       setTimeout(() => setMessage(''), 2000);
       setInputValue("");
+      updateList({code: inputValue, redeemed: false} as Incentive)
     } else {
       setMessage('An error occured');
     }

--- a/app/javascript/components/ResearcherApp/IncentiveForm.tsx
+++ b/app/javascript/components/ResearcherApp/IncentiveForm.tsx
@@ -1,21 +1,21 @@
 import * as React from 'react';
 import { useState } from 'react';
-import { updateIncentive } from '@api/endpoints';
+import { createIncentive } from '@api/endpoints';
 
 interface Props {
-  data: Incentive[];
 }
-export const IncentiveForm: React.FC<Props> = ({ data }) => {
+export const IncentiveForm: React.FC<Props> = () => {
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState('');
-  const [inputValue, setInputValue] = useState(data[0].code);
+  const [inputValue, setInputValue] = useState("");
 
-  async function handleClickSave() {
+  async function handleClickCreate() {
     setSaving(true);
-    const incentive = await updateIncentive(data[0].id, { code: inputValue });
+    const incentive = await createIncentive({ code: inputValue });
     if (incentive) {
       setMessage('Successfully updated!');
       setTimeout(() => setMessage(''), 2000);
+      setInputValue("");
     } else {
       setMessage('An error occured');
     }
@@ -36,9 +36,9 @@ export const IncentiveForm: React.FC<Props> = ({ data }) => {
         <button
           disabled={saving}
           className="hover:bg-gray-100 bg-gray-200 rounded-md px-4 py-2"
-          onClick={handleClickSave}
+          onClick={handleClickCreate}
         >
-          Save
+          Create
         </button>
       </div>
       {message && <div className="text-gray-600 italic">{message}</div>}

--- a/app/javascript/components/ResearcherApp/IncentiveList.tsx
+++ b/app/javascript/components/ResearcherApp/IncentiveList.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+
+
+interface Props {
+    data: Incentive[];
+}
+export const IncentiveList: React.FC<Props> = ({ data }) => {
+
+    const listIncentives = data.map((incentive) =>
+        <tr>
+            <td>{incentive.code}</td>
+            <td>{incentive.redeemed ? "YES" : "NO"}</td>
+        </tr>
+    )
+    return (
+        <div>
+            <div className="flex space-x-2 pb-4">
+                <table style={{textAlign: "center", width: 300}}>
+                    <th>Code</th>
+                    <th>Redeemed?</th>
+                    {listIncentives}
+                </table>
+            </div>
+        </div>
+    );
+};

--- a/app/javascript/components/ResearcherApp/ResearcherApp.tsx
+++ b/app/javascript/components/ResearcherApp/ResearcherApp.tsx
@@ -22,7 +22,7 @@ export const ResearcherApp: React.FC = () => {
 
       {loading && <span>Loading...</span>}
 
-      {!loading && <IncentiveForm data={data} />}
+      {!loading && <IncentiveForm />}
     </div>
   );
 };

--- a/app/javascript/components/ResearcherApp/ResearcherApp.tsx
+++ b/app/javascript/components/ResearcherApp/ResearcherApp.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useEffect, useState } from 'react';
 import { getIncentives } from '@api/endpoints';
 import { IncentiveForm } from './IncentiveForm';
+import { IncentiveList } from './IncentiveList';
 
 export const ResearcherApp: React.FC = () => {
   const [loading, setLoading] = useState(true);
@@ -15,6 +16,12 @@ export const ResearcherApp: React.FC = () => {
       });
   }, []);
 
+  const updateList = (incentive: Incentive) => {
+    const newData = [...data]
+    newData.unshift(incentive);
+    setData(newData);
+  }
+
   return (
     <div className="px-12 py-6">
       <h1 className="text-2xl font-bold mb-6">Setup incentive</h1>
@@ -22,7 +29,9 @@ export const ResearcherApp: React.FC = () => {
 
       {loading && <span>Loading...</span>}
 
-      {!loading && <IncentiveForm />}
+      {!loading && <IncentiveForm updateList={updateList} />}
+
+      {!loading && <IncentiveList data={data} />}
     </div>
   );
 };

--- a/app/javascript/components/types.d.ts
+++ b/app/javascript/components/types.d.ts
@@ -6,4 +6,5 @@ interface Model {
 
 interface Incentive extends Model {
   code: string;
+  redeemed: boolean;
 }

--- a/app/models/incentive.rb
+++ b/app/models/incentive.rb
@@ -1,2 +1,3 @@
 class Incentive < ApplicationRecord
+    validates :code, presence:true, uniqueness: {case_sensitive: false}
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   namespace :api, defaults: {format: :json} do
-    resources :incentives
+    # resources :incentives
+    resources :incentives do
+      get :redeem, on: :collection
+    end
   end
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   get :redeem, to: 'candidates#show'

--- a/db/migrate/20210730032208_add_redeemed_for_incentive.rb
+++ b/db/migrate/20210730032208_add_redeemed_for_incentive.rb
@@ -1,5 +1,5 @@
 class AddRedeemedForIncentive < ActiveRecord::Migration[6.0]
   def change
-    add_column :incentives, :redeemed, :boolean, default: false, unique: true
+    add_column :incentives, :redeemed, :boolean, default: false
   end
 end

--- a/db/migrate/20210730032208_add_redeemed_for_incentive.rb
+++ b/db/migrate/20210730032208_add_redeemed_for_incentive.rb
@@ -1,5 +1,5 @@
 class AddRedeemedForIncentive < ActiveRecord::Migration[6.0]
   def change
-    add_column :incentives, :redeemed, :boolean, default: false
+    add_column :incentives, :redeemed, :boolean, default: false, unique: true
   end
 end

--- a/db/migrate/20210730032208_add_redeemed_for_incentive.rb
+++ b/db/migrate/20210730032208_add_redeemed_for_incentive.rb
@@ -1,0 +1,5 @@
+class AddRedeemedForIncentive < ActiveRecord::Migration[6.0]
+  def change
+    add_column :incentives, :redeemed, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_07_012944) do
+ActiveRecord::Schema.define(version: 2021_07_30_032208) do
 
   create_table "incentives", force: :cascade do |t|
     t.string "code"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "redeemed", default: false
   end
 
 end

--- a/test/controllers/api/incentives_controller_test.rb
+++ b/test/controllers/api/incentives_controller_test.rb
@@ -18,16 +18,31 @@ class Api::IncentivesControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  describe 'PUT #update' do
-    subject { put "/api/incentives/#{incentive.id}", params: {incentive: params} }
+  describe 'POST #create' do
+    subject { post "/api/incentives", params: {incentive: params} }
 
-    let(:incentive) { create(:incentive) }
     let(:params) { {code: 'FOOBAR'} }
 
-    it 'should update the incentive' do
+    it 'should create the incentive' do
       subject
       assert_response :success
-      assert_equal 'FOOBAR', incentive.reload.code
+      data = response.parsed_body
+      assert_equal 'FOOBAR', data['code']
+    end
+  end
+
+  describe 'Is Unique' do
+    subject {get '/api/incentives/redeem'}
+
+    setup do
+      create(:incentive, code: 'COUPON1')
+    end
+
+    it 'should be unique' do
+      subject
+      assert_response :success
+      data = response.parsed_body
+      assert_equal true, data['redeemed']
     end
   end
 end

--- a/test/system/candidate_test.rb
+++ b/test/system/candidate_test.rb
@@ -4,13 +4,14 @@ class CandidateTest < ApplicationSystemTestCase
 
   describe 'redeeming the incentive' do
     setup do 
-      create(:incentive, code: 'COUPON_123')
+      create(:incentive, code: 'COUPON_123', redeemed: true)
+      create(:incentive, code: 'COUPON_456', redeemed: false)
     end
 
     it 'should give the latest coupon' do
       visit '/redeem'
       click_on 'Redeem'
-      assert_text 'COUPON_123'
+      assert_text 'COUPON_456'
     end
   end
 end

--- a/test/system/researcher_test.rb
+++ b/test/system/researcher_test.rb
@@ -9,23 +9,21 @@ class ResearcherTest < ApplicationSystemTestCase
 
     it 'should_show_the_current_coupon' do
       visit '/setup'
-      assert_equal 'COUPON_123', find_field('incentive_code').value
+      assert_text 'COUPON_123' #shows on our list
     end
   end
 
-  describe 'updating_incentive' do
-    let(:incentive) { create(:incentive, code: 'OLD_CODE')}
+  describe 'creating_incentive' do
 
-    setup do
-      incentive ## create incentive beforehand as let doesnt run until called
-    end
+    # setup do
+    #   incentive ## create incentive beforehand as let doesnt run until called
+    # end
     
     it 'should_update_the_code' do
       visit '/setup'
-      fill_in 'incentive_code', with: 'NEW_CODE'
-      click_on 'Save'
-      assert_text 'Successfully updated'
-      assert_equal 'NEW_CODE', incentive.reload.code
+      fill_in 'incentive_code', with: 'COUPON_123'
+      click_on 'Create'
+      assert_text 'COUPON_123' # shows on list
     end
   end
 end


### PR DESCRIPTION
Added functionality outlined in the doc.

- Added migration to support multiple codes. Added a `redeemed` field to track if a code has been used
- Added backend support for creating a new coupon code vs the old method of just updating the one existing code
- Created an endpoint for listing all existing codes sorted by creation date.

- Created front end view for listing existing code and creating new ones
- Updated front end for calling API to redeem a code when a user requests to redeem one